### PR TITLE
#6 add summary to database documentation

### DIFF
--- a/Documentation/Database/Readme.md
+++ b/Documentation/Database/Readme.md
@@ -1,5 +1,20 @@
 # CodeTimeTracker Database Documentation
 
+## Summary
+- [Introduction](#introduction)
+- [Database Type](#database-type)
+- [Table Structure](#table-structure)
+  - [Users](#users)
+  - [Activities](#activities)
+  - [UserPreferences](#user-preferences)
+  - [Tags](#tags)
+  - [ActivitiesTags](#activities-tags)
+  - [Sprints](#sprints)
+  - [TagsSprints](#tags-sprints)
+  - [Companies](#companies)
+- [Relationships](#relationships)
+- [Database Diagram](#database-Diagram)
+
 ## Introduction
 
 This document outlines the database schema for the CodeTimeTracker project, a system designed to track coding activities and preferences for users. The database is structured to store user information, preferences, activities, tags associated with these activities, companies, sprints, and the relationships between tags and sprints.


### PR DESCRIPTION
This pull request introduces a navigable index to the database documentation, enhancing user experience by facilitating easier navigation through sections. The index is created using Markdown to ensure compatibility with GitHub's viewing capabilities.

### Changes:

- Added an index at the beginning of the `Documentation\Database\Readme.md` file.
- Updated all sections within the documentation to include anchor links back to the index for convenience.
- Tested all links in the index to ensure they correctly navigate to the respective sections within the document.

closes #6 